### PR TITLE
Integrated social-auth-app-django  - Users can register and login using their FB account.

### DIFF
--- a/account/admin.py
+++ b/account/admin.py
@@ -11,6 +11,7 @@ class ProfessionalProfileAdmin(admin.ModelAdmin):
         'user',
     ]
 
+
 admin.site.register(ProfessionalProfile, ProfessionalProfileAdmin)
 
 
@@ -25,5 +26,6 @@ class IndustryCategoryAdmin(admin.ModelAdmin):
         'name_es',
         'name_en',
     ]
+
 
 admin.site.register(IndustryCategory, IndustryCategoryAdmin)

--- a/account/templates/account/professional_profile.html
+++ b/account/templates/account/professional_profile.html
@@ -37,15 +37,19 @@
                         </div>
 
                         <div class="panel-body">
+                            {% if profile.user.country %}
                             <div>
                                 <img src="{{ profile.country.country.flag }}">
                                 <span>{{ profile.user.country }}</span>
                             </div>
+                            {% endif %}
 
+                            {% if profile.user.city %}
                             <div>
                                 <i class="fa fa-location-arrow" aria-hidden="true"></i>
                                 <span>{{ profile.user.city }} {% if profile.user.state %}, {{ profile.user.state }}.{% endif %}</span>
                             </div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/account/templates/account/professional_profile.html
+++ b/account/templates/account/professional_profile.html
@@ -20,12 +20,15 @@
                             <ul class="QJVentureDetCats">
                             {% for industry_category in profile.industry_categories.all %}
                                 <li>{{ industry_category }}</li>
+                            {% empty %}
+                                <li>{{ profile.user.first_name }} has not added industry sectors.</li>
                             {% endfor %}
                             </ul>
                         </div>
                     </div>
                 </div>
 
+                {% if profile.user.country or profile.user.city %}
                 <div class="QJVentureDetLocation">
                     <div class="panel panel-default">
                         <div class="panel-heading">
@@ -46,6 +49,7 @@
                         </div>
                     </div>
                 </div>
+                {% endif %}
             </div>
 
             <div class="col-sm-12 col-md-9 col-lg-9">
@@ -54,6 +58,8 @@
                     <div class="QJRedactorContent">
                         {{ profile.description_en|safe }}
                     </div>
+                {% else %}
+                <p>There is not information about this profile.</p>
                 {% endif %}
                 </div>
             </div>

--- a/account/views.py
+++ b/account/views.py
@@ -19,8 +19,6 @@ from django.views.generic import UpdateView
 from django.contrib import auth
 from account.models import User
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.utils.text import slugify
-from django.utils.crypto import get_random_string
 
 from account.forms import SignUpForm
 from account.forms import ProfileForm
@@ -33,7 +31,6 @@ from app.mixins import CustomUserMixin
 from entrepreneur.data import ACTIVE_MEMBERSHIP
 from entrepreneur.data import REJECTED_MEMBERSHIP
 from entrepreneur.data import SENT_INVITATION
-from entrepreneur.models import Venture
 from place.utils import get_user_country
 from place.models import Country
 from place.models import City
@@ -50,6 +47,8 @@ class SignUpFormView(FormView):
         password = form.cleaned_data['password']
 
         user = User.objects.create_user(
+            first_name,
+            last_name,
             email,
             password,
         )
@@ -63,28 +62,6 @@ class SignUpFormView(FormView):
             user.country = country_instance
 
         user.save()
-
-        slug = slugify(
-            u'{0}{1}'.format(
-                first_name,
-                last_name,
-            )
-        )
-
-        if (
-            Venture.objects.filter(slug=slug) or
-            ProfessionalProfile.objects.filter(slug=slug)
-        ):
-            random_string = get_random_string(length=6)
-            slug = '{0}-{1}'.format(
-                slug,
-                random_string.lower(),
-            )
-
-        ProfessionalProfile.objects.create(
-            user=user,
-            slug=slug,
-        )
 
         authenticated_user = auth.authenticate(
             username=user.email,

--- a/account/views.py
+++ b/account/views.py
@@ -84,7 +84,7 @@ def profile_as_JSON(profile):
     """
     name = '{0} ({1})'.format(
         profile.user.get_full_name,
-        profile.user.email,
+        profile.slug,
     )
 
     return {

--- a/app/context_processors.py
+++ b/app/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def facebook_app_id(request):
+    return {'FACEBOOK_APP_ID': settings.SOCIAL_AUTH_FACEBOOK_KEY}

--- a/app/settings.py
+++ b/app/settings.py
@@ -125,6 +125,7 @@ SOCIAL_AUTH_PIPELINE = (
 )
 
 SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
+
 SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
     'fields': 'first_name, last_name, email',
 }

--- a/app/settings.py
+++ b/app/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = PROJECT_APPS + (
 
     'django_extensions',
     'django_countries',
+    'social_django',
     'widget_tweaks',
     'storages',
 )
@@ -41,6 +42,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'social_django.middleware.SocialAuthExceptionMiddleware',
 ]
 
 ROOT_URLCONF = 'app.urls'
@@ -56,6 +59,10 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+
+                'social_django.context_processors.backends',
+                'social_django.context_processors.login_redirect',
+                'app.context_processors.facebook_app_id',
             ],
         },
     },
@@ -95,9 +102,41 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTH_USER_MODEL = 'account.User'
 LOGIN_URL = 'auth_login'
-LOGIN_REDIRECT_URL = 'home'
+LOGIN_REDIRECT_URL = 'account:signup_landing'
 LOGOUT_URL = 'user_logout'
 LOGOUT_REDIRECT_URL = 'home'
+
+
+AUTHENTICATION_BACKENDS = (
+    'social_core.backends.facebook.FacebookOAuth2',
+    'django.contrib.auth.backends.ModelBackend',
+)
+
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
+    'social_core.pipeline.social_auth.associate_by_email',
+)
+
+SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
+    'fields': 'first_name, last_name, email',
+}
+SOCIAL_AUTH_USER_FIELDS = [
+    'first_name',
+    'last_name',
+    'email',
+]
+
+
+SOCIAL_AUTH_FACEBOOK_KEY = 'edit-it'
+SOCIAL_AUTH_FACEBOOK_SECRET = 'edit-it'
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'

--- a/app/static/css/libs/bootstrap-social.css
+++ b/app/static/css/libs/bootstrap-social.css
@@ -1,0 +1,147 @@
+/*
+ * Social Buttons for Bootstrap
+ *
+ * Copyright 2013-2016 Panayiotis Lipiridis
+ * Licensed under the MIT License
+ *
+ * https://github.com/lipis/bootstrap-social
+ */
+
+.btn-social{position:relative;padding-left:44px;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.btn-social>:first-child{position:absolute;left:0;top:0;bottom:0;width:32px;line-height:34px;font-size:1.6em;text-align:center;border-right:1px solid rgba(0,0,0,0.2)}
+.btn-social.btn-lg{padding-left:61px}.btn-social.btn-lg>:first-child{line-height:45px;width:45px;font-size:1.8em}
+.btn-social.btn-sm{padding-left:38px}.btn-social.btn-sm>:first-child{line-height:28px;width:28px;font-size:1.4em}
+.btn-social.btn-xs{padding-left:30px}.btn-social.btn-xs>:first-child{line-height:20px;width:20px;font-size:1.2em}
+.btn-social-icon{position:relative;padding-left:44px;text-align:left;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;height:34px;width:34px;padding:0}.btn-social-icon>:first-child{position:absolute;left:0;top:0;bottom:0;width:32px;line-height:34px;font-size:1.6em;text-align:center;border-right:1px solid rgba(0,0,0,0.2)}
+.btn-social-icon.btn-lg{padding-left:61px}.btn-social-icon.btn-lg>:first-child{line-height:45px;width:45px;font-size:1.8em}
+.btn-social-icon.btn-sm{padding-left:38px}.btn-social-icon.btn-sm>:first-child{line-height:28px;width:28px;font-size:1.4em}
+.btn-social-icon.btn-xs{padding-left:30px}.btn-social-icon.btn-xs>:first-child{line-height:20px;width:20px;font-size:1.2em}
+.btn-social-icon>:first-child{border:none;text-align:center;width:100% !important}
+.btn-social-icon.btn-lg{height:45px;width:45px;padding-left:0;padding-right:0}
+.btn-social-icon.btn-sm{height:30px;width:30px;padding-left:0;padding-right:0}
+.btn-social-icon.btn-xs{height:22px;width:22px;padding-left:0;padding-right:0}
+.btn-adn{color:#fff;background-color:#d87a68;border-color:rgba(0,0,0,0.2)}.btn-adn:focus,.btn-adn.focus{color:#fff;background-color:#ce563f;border-color:rgba(0,0,0,0.2)}
+.btn-adn:hover{color:#fff;background-color:#ce563f;border-color:rgba(0,0,0,0.2)}
+.btn-adn:active,.btn-adn.active,.open>.dropdown-toggle.btn-adn{color:#fff;background-color:#ce563f;border-color:rgba(0,0,0,0.2)}.btn-adn:active:hover,.btn-adn.active:hover,.open>.dropdown-toggle.btn-adn:hover,.btn-adn:active:focus,.btn-adn.active:focus,.open>.dropdown-toggle.btn-adn:focus,.btn-adn:active.focus,.btn-adn.active.focus,.open>.dropdown-toggle.btn-adn.focus{color:#fff;background-color:#b94630;border-color:rgba(0,0,0,0.2)}
+.btn-adn:active,.btn-adn.active,.open>.dropdown-toggle.btn-adn{background-image:none}
+.btn-adn.disabled:hover,.btn-adn[disabled]:hover,fieldset[disabled] .btn-adn:hover,.btn-adn.disabled:focus,.btn-adn[disabled]:focus,fieldset[disabled] .btn-adn:focus,.btn-adn.disabled.focus,.btn-adn[disabled].focus,fieldset[disabled] .btn-adn.focus{background-color:#d87a68;border-color:rgba(0,0,0,0.2)}
+.btn-adn .badge{color:#d87a68;background-color:#fff}
+.btn-bitbucket{color:#fff;background-color:#205081;border-color:rgba(0,0,0,0.2)}.btn-bitbucket:focus,.btn-bitbucket.focus{color:#fff;background-color:#163758;border-color:rgba(0,0,0,0.2)}
+.btn-bitbucket:hover{color:#fff;background-color:#163758;border-color:rgba(0,0,0,0.2)}
+.btn-bitbucket:active,.btn-bitbucket.active,.open>.dropdown-toggle.btn-bitbucket{color:#fff;background-color:#163758;border-color:rgba(0,0,0,0.2)}.btn-bitbucket:active:hover,.btn-bitbucket.active:hover,.open>.dropdown-toggle.btn-bitbucket:hover,.btn-bitbucket:active:focus,.btn-bitbucket.active:focus,.open>.dropdown-toggle.btn-bitbucket:focus,.btn-bitbucket:active.focus,.btn-bitbucket.active.focus,.open>.dropdown-toggle.btn-bitbucket.focus{color:#fff;background-color:#0f253c;border-color:rgba(0,0,0,0.2)}
+.btn-bitbucket:active,.btn-bitbucket.active,.open>.dropdown-toggle.btn-bitbucket{background-image:none}
+.btn-bitbucket.disabled:hover,.btn-bitbucket[disabled]:hover,fieldset[disabled] .btn-bitbucket:hover,.btn-bitbucket.disabled:focus,.btn-bitbucket[disabled]:focus,fieldset[disabled] .btn-bitbucket:focus,.btn-bitbucket.disabled.focus,.btn-bitbucket[disabled].focus,fieldset[disabled] .btn-bitbucket.focus{background-color:#205081;border-color:rgba(0,0,0,0.2)}
+.btn-bitbucket .badge{color:#205081;background-color:#fff}
+.btn-dropbox{color:#fff;background-color:#1087dd;border-color:rgba(0,0,0,0.2)}.btn-dropbox:focus,.btn-dropbox.focus{color:#fff;background-color:#0d6aad;border-color:rgba(0,0,0,0.2)}
+.btn-dropbox:hover{color:#fff;background-color:#0d6aad;border-color:rgba(0,0,0,0.2)}
+.btn-dropbox:active,.btn-dropbox.active,.open>.dropdown-toggle.btn-dropbox{color:#fff;background-color:#0d6aad;border-color:rgba(0,0,0,0.2)}.btn-dropbox:active:hover,.btn-dropbox.active:hover,.open>.dropdown-toggle.btn-dropbox:hover,.btn-dropbox:active:focus,.btn-dropbox.active:focus,.open>.dropdown-toggle.btn-dropbox:focus,.btn-dropbox:active.focus,.btn-dropbox.active.focus,.open>.dropdown-toggle.btn-dropbox.focus{color:#fff;background-color:#0a568c;border-color:rgba(0,0,0,0.2)}
+.btn-dropbox:active,.btn-dropbox.active,.open>.dropdown-toggle.btn-dropbox{background-image:none}
+.btn-dropbox.disabled:hover,.btn-dropbox[disabled]:hover,fieldset[disabled] .btn-dropbox:hover,.btn-dropbox.disabled:focus,.btn-dropbox[disabled]:focus,fieldset[disabled] .btn-dropbox:focus,.btn-dropbox.disabled.focus,.btn-dropbox[disabled].focus,fieldset[disabled] .btn-dropbox.focus{background-color:#1087dd;border-color:rgba(0,0,0,0.2)}
+.btn-dropbox .badge{color:#1087dd;background-color:#fff}
+.btn-facebook{color:#fff;background-color:#3b5998;border-color:rgba(0,0,0,0.2)}.btn-facebook:focus,.btn-facebook.focus{color:#fff;background-color:#2d4373;border-color:rgba(0,0,0,0.2)}
+.btn-facebook:hover{color:#fff;background-color:#2d4373;border-color:rgba(0,0,0,0.2)}
+.btn-facebook:active,.btn-facebook.active,.open>.dropdown-toggle.btn-facebook{color:#fff;background-color:#2d4373;border-color:rgba(0,0,0,0.2)}.btn-facebook:active:hover,.btn-facebook.active:hover,.open>.dropdown-toggle.btn-facebook:hover,.btn-facebook:active:focus,.btn-facebook.active:focus,.open>.dropdown-toggle.btn-facebook:focus,.btn-facebook:active.focus,.btn-facebook.active.focus,.open>.dropdown-toggle.btn-facebook.focus{color:#fff;background-color:#23345a;border-color:rgba(0,0,0,0.2)}
+.btn-facebook:active,.btn-facebook.active,.open>.dropdown-toggle.btn-facebook{background-image:none}
+.btn-facebook.disabled:hover,.btn-facebook[disabled]:hover,fieldset[disabled] .btn-facebook:hover,.btn-facebook.disabled:focus,.btn-facebook[disabled]:focus,fieldset[disabled] .btn-facebook:focus,.btn-facebook.disabled.focus,.btn-facebook[disabled].focus,fieldset[disabled] .btn-facebook.focus{background-color:#3b5998;border-color:rgba(0,0,0,0.2)}
+.btn-facebook .badge{color:#3b5998;background-color:#fff}
+.btn-flickr{color:#fff;background-color:#ff0084;border-color:rgba(0,0,0,0.2)}.btn-flickr:focus,.btn-flickr.focus{color:#fff;background-color:#cc006a;border-color:rgba(0,0,0,0.2)}
+.btn-flickr:hover{color:#fff;background-color:#cc006a;border-color:rgba(0,0,0,0.2)}
+.btn-flickr:active,.btn-flickr.active,.open>.dropdown-toggle.btn-flickr{color:#fff;background-color:#cc006a;border-color:rgba(0,0,0,0.2)}.btn-flickr:active:hover,.btn-flickr.active:hover,.open>.dropdown-toggle.btn-flickr:hover,.btn-flickr:active:focus,.btn-flickr.active:focus,.open>.dropdown-toggle.btn-flickr:focus,.btn-flickr:active.focus,.btn-flickr.active.focus,.open>.dropdown-toggle.btn-flickr.focus{color:#fff;background-color:#a80057;border-color:rgba(0,0,0,0.2)}
+.btn-flickr:active,.btn-flickr.active,.open>.dropdown-toggle.btn-flickr{background-image:none}
+.btn-flickr.disabled:hover,.btn-flickr[disabled]:hover,fieldset[disabled] .btn-flickr:hover,.btn-flickr.disabled:focus,.btn-flickr[disabled]:focus,fieldset[disabled] .btn-flickr:focus,.btn-flickr.disabled.focus,.btn-flickr[disabled].focus,fieldset[disabled] .btn-flickr.focus{background-color:#ff0084;border-color:rgba(0,0,0,0.2)}
+.btn-flickr .badge{color:#ff0084;background-color:#fff}
+.btn-foursquare{color:#fff;background-color:#f94877;border-color:rgba(0,0,0,0.2)}.btn-foursquare:focus,.btn-foursquare.focus{color:#fff;background-color:#f71752;border-color:rgba(0,0,0,0.2)}
+.btn-foursquare:hover{color:#fff;background-color:#f71752;border-color:rgba(0,0,0,0.2)}
+.btn-foursquare:active,.btn-foursquare.active,.open>.dropdown-toggle.btn-foursquare{color:#fff;background-color:#f71752;border-color:rgba(0,0,0,0.2)}.btn-foursquare:active:hover,.btn-foursquare.active:hover,.open>.dropdown-toggle.btn-foursquare:hover,.btn-foursquare:active:focus,.btn-foursquare.active:focus,.open>.dropdown-toggle.btn-foursquare:focus,.btn-foursquare:active.focus,.btn-foursquare.active.focus,.open>.dropdown-toggle.btn-foursquare.focus{color:#fff;background-color:#e30742;border-color:rgba(0,0,0,0.2)}
+.btn-foursquare:active,.btn-foursquare.active,.open>.dropdown-toggle.btn-foursquare{background-image:none}
+.btn-foursquare.disabled:hover,.btn-foursquare[disabled]:hover,fieldset[disabled] .btn-foursquare:hover,.btn-foursquare.disabled:focus,.btn-foursquare[disabled]:focus,fieldset[disabled] .btn-foursquare:focus,.btn-foursquare.disabled.focus,.btn-foursquare[disabled].focus,fieldset[disabled] .btn-foursquare.focus{background-color:#f94877;border-color:rgba(0,0,0,0.2)}
+.btn-foursquare .badge{color:#f94877;background-color:#fff}
+.btn-github{color:#fff;background-color:#444;border-color:rgba(0,0,0,0.2)}.btn-github:focus,.btn-github.focus{color:#fff;background-color:#2b2b2b;border-color:rgba(0,0,0,0.2)}
+.btn-github:hover{color:#fff;background-color:#2b2b2b;border-color:rgba(0,0,0,0.2)}
+.btn-github:active,.btn-github.active,.open>.dropdown-toggle.btn-github{color:#fff;background-color:#2b2b2b;border-color:rgba(0,0,0,0.2)}.btn-github:active:hover,.btn-github.active:hover,.open>.dropdown-toggle.btn-github:hover,.btn-github:active:focus,.btn-github.active:focus,.open>.dropdown-toggle.btn-github:focus,.btn-github:active.focus,.btn-github.active.focus,.open>.dropdown-toggle.btn-github.focus{color:#fff;background-color:#191919;border-color:rgba(0,0,0,0.2)}
+.btn-github:active,.btn-github.active,.open>.dropdown-toggle.btn-github{background-image:none}
+.btn-github.disabled:hover,.btn-github[disabled]:hover,fieldset[disabled] .btn-github:hover,.btn-github.disabled:focus,.btn-github[disabled]:focus,fieldset[disabled] .btn-github:focus,.btn-github.disabled.focus,.btn-github[disabled].focus,fieldset[disabled] .btn-github.focus{background-color:#444;border-color:rgba(0,0,0,0.2)}
+.btn-github .badge{color:#444;background-color:#fff}
+.btn-google{color:#fff;background-color:#dd4b39;border-color:rgba(0,0,0,0.2)}.btn-google:focus,.btn-google.focus{color:#fff;background-color:#c23321;border-color:rgba(0,0,0,0.2)}
+.btn-google:hover{color:#fff;background-color:#c23321;border-color:rgba(0,0,0,0.2)}
+.btn-google:active,.btn-google.active,.open>.dropdown-toggle.btn-google{color:#fff;background-color:#c23321;border-color:rgba(0,0,0,0.2)}.btn-google:active:hover,.btn-google.active:hover,.open>.dropdown-toggle.btn-google:hover,.btn-google:active:focus,.btn-google.active:focus,.open>.dropdown-toggle.btn-google:focus,.btn-google:active.focus,.btn-google.active.focus,.open>.dropdown-toggle.btn-google.focus{color:#fff;background-color:#a32b1c;border-color:rgba(0,0,0,0.2)}
+.btn-google:active,.btn-google.active,.open>.dropdown-toggle.btn-google{background-image:none}
+.btn-google.disabled:hover,.btn-google[disabled]:hover,fieldset[disabled] .btn-google:hover,.btn-google.disabled:focus,.btn-google[disabled]:focus,fieldset[disabled] .btn-google:focus,.btn-google.disabled.focus,.btn-google[disabled].focus,fieldset[disabled] .btn-google.focus{background-color:#dd4b39;border-color:rgba(0,0,0,0.2)}
+.btn-google .badge{color:#dd4b39;background-color:#fff}
+.btn-instagram{color:#fff;background-color:#3f729b;border-color:rgba(0,0,0,0.2)}.btn-instagram:focus,.btn-instagram.focus{color:#fff;background-color:#305777;border-color:rgba(0,0,0,0.2)}
+.btn-instagram:hover{color:#fff;background-color:#305777;border-color:rgba(0,0,0,0.2)}
+.btn-instagram:active,.btn-instagram.active,.open>.dropdown-toggle.btn-instagram{color:#fff;background-color:#305777;border-color:rgba(0,0,0,0.2)}.btn-instagram:active:hover,.btn-instagram.active:hover,.open>.dropdown-toggle.btn-instagram:hover,.btn-instagram:active:focus,.btn-instagram.active:focus,.open>.dropdown-toggle.btn-instagram:focus,.btn-instagram:active.focus,.btn-instagram.active.focus,.open>.dropdown-toggle.btn-instagram.focus{color:#fff;background-color:#26455d;border-color:rgba(0,0,0,0.2)}
+.btn-instagram:active,.btn-instagram.active,.open>.dropdown-toggle.btn-instagram{background-image:none}
+.btn-instagram.disabled:hover,.btn-instagram[disabled]:hover,fieldset[disabled] .btn-instagram:hover,.btn-instagram.disabled:focus,.btn-instagram[disabled]:focus,fieldset[disabled] .btn-instagram:focus,.btn-instagram.disabled.focus,.btn-instagram[disabled].focus,fieldset[disabled] .btn-instagram.focus{background-color:#3f729b;border-color:rgba(0,0,0,0.2)}
+.btn-instagram .badge{color:#3f729b;background-color:#fff}
+.btn-linkedin{color:#fff;background-color:#007bb6;border-color:rgba(0,0,0,0.2)}.btn-linkedin:focus,.btn-linkedin.focus{color:#fff;background-color:#005983;border-color:rgba(0,0,0,0.2)}
+.btn-linkedin:hover{color:#fff;background-color:#005983;border-color:rgba(0,0,0,0.2)}
+.btn-linkedin:active,.btn-linkedin.active,.open>.dropdown-toggle.btn-linkedin{color:#fff;background-color:#005983;border-color:rgba(0,0,0,0.2)}.btn-linkedin:active:hover,.btn-linkedin.active:hover,.open>.dropdown-toggle.btn-linkedin:hover,.btn-linkedin:active:focus,.btn-linkedin.active:focus,.open>.dropdown-toggle.btn-linkedin:focus,.btn-linkedin:active.focus,.btn-linkedin.active.focus,.open>.dropdown-toggle.btn-linkedin.focus{color:#fff;background-color:#00405f;border-color:rgba(0,0,0,0.2)}
+.btn-linkedin:active,.btn-linkedin.active,.open>.dropdown-toggle.btn-linkedin{background-image:none}
+.btn-linkedin.disabled:hover,.btn-linkedin[disabled]:hover,fieldset[disabled] .btn-linkedin:hover,.btn-linkedin.disabled:focus,.btn-linkedin[disabled]:focus,fieldset[disabled] .btn-linkedin:focus,.btn-linkedin.disabled.focus,.btn-linkedin[disabled].focus,fieldset[disabled] .btn-linkedin.focus{background-color:#007bb6;border-color:rgba(0,0,0,0.2)}
+.btn-linkedin .badge{color:#007bb6;background-color:#fff}
+.btn-microsoft{color:#fff;background-color:#2672ec;border-color:rgba(0,0,0,0.2)}.btn-microsoft:focus,.btn-microsoft.focus{color:#fff;background-color:#125acd;border-color:rgba(0,0,0,0.2)}
+.btn-microsoft:hover{color:#fff;background-color:#125acd;border-color:rgba(0,0,0,0.2)}
+.btn-microsoft:active,.btn-microsoft.active,.open>.dropdown-toggle.btn-microsoft{color:#fff;background-color:#125acd;border-color:rgba(0,0,0,0.2)}.btn-microsoft:active:hover,.btn-microsoft.active:hover,.open>.dropdown-toggle.btn-microsoft:hover,.btn-microsoft:active:focus,.btn-microsoft.active:focus,.open>.dropdown-toggle.btn-microsoft:focus,.btn-microsoft:active.focus,.btn-microsoft.active.focus,.open>.dropdown-toggle.btn-microsoft.focus{color:#fff;background-color:#0f4bac;border-color:rgba(0,0,0,0.2)}
+.btn-microsoft:active,.btn-microsoft.active,.open>.dropdown-toggle.btn-microsoft{background-image:none}
+.btn-microsoft.disabled:hover,.btn-microsoft[disabled]:hover,fieldset[disabled] .btn-microsoft:hover,.btn-microsoft.disabled:focus,.btn-microsoft[disabled]:focus,fieldset[disabled] .btn-microsoft:focus,.btn-microsoft.disabled.focus,.btn-microsoft[disabled].focus,fieldset[disabled] .btn-microsoft.focus{background-color:#2672ec;border-color:rgba(0,0,0,0.2)}
+.btn-microsoft .badge{color:#2672ec;background-color:#fff}
+.btn-odnoklassniki{color:#fff;background-color:#f4731c;border-color:rgba(0,0,0,0.2)}.btn-odnoklassniki:focus,.btn-odnoklassniki.focus{color:#fff;background-color:#d35b0a;border-color:rgba(0,0,0,0.2)}
+.btn-odnoklassniki:hover{color:#fff;background-color:#d35b0a;border-color:rgba(0,0,0,0.2)}
+.btn-odnoklassniki:active,.btn-odnoklassniki.active,.open>.dropdown-toggle.btn-odnoklassniki{color:#fff;background-color:#d35b0a;border-color:rgba(0,0,0,0.2)}.btn-odnoklassniki:active:hover,.btn-odnoklassniki.active:hover,.open>.dropdown-toggle.btn-odnoklassniki:hover,.btn-odnoklassniki:active:focus,.btn-odnoklassniki.active:focus,.open>.dropdown-toggle.btn-odnoklassniki:focus,.btn-odnoklassniki:active.focus,.btn-odnoklassniki.active.focus,.open>.dropdown-toggle.btn-odnoklassniki.focus{color:#fff;background-color:#b14c09;border-color:rgba(0,0,0,0.2)}
+.btn-odnoklassniki:active,.btn-odnoklassniki.active,.open>.dropdown-toggle.btn-odnoklassniki{background-image:none}
+.btn-odnoklassniki.disabled:hover,.btn-odnoklassniki[disabled]:hover,fieldset[disabled] .btn-odnoklassniki:hover,.btn-odnoklassniki.disabled:focus,.btn-odnoklassniki[disabled]:focus,fieldset[disabled] .btn-odnoklassniki:focus,.btn-odnoklassniki.disabled.focus,.btn-odnoklassniki[disabled].focus,fieldset[disabled] .btn-odnoklassniki.focus{background-color:#f4731c;border-color:rgba(0,0,0,0.2)}
+.btn-odnoklassniki .badge{color:#f4731c;background-color:#fff}
+.btn-openid{color:#fff;background-color:#f7931e;border-color:rgba(0,0,0,0.2)}.btn-openid:focus,.btn-openid.focus{color:#fff;background-color:#da7908;border-color:rgba(0,0,0,0.2)}
+.btn-openid:hover{color:#fff;background-color:#da7908;border-color:rgba(0,0,0,0.2)}
+.btn-openid:active,.btn-openid.active,.open>.dropdown-toggle.btn-openid{color:#fff;background-color:#da7908;border-color:rgba(0,0,0,0.2)}.btn-openid:active:hover,.btn-openid.active:hover,.open>.dropdown-toggle.btn-openid:hover,.btn-openid:active:focus,.btn-openid.active:focus,.open>.dropdown-toggle.btn-openid:focus,.btn-openid:active.focus,.btn-openid.active.focus,.open>.dropdown-toggle.btn-openid.focus{color:#fff;background-color:#b86607;border-color:rgba(0,0,0,0.2)}
+.btn-openid:active,.btn-openid.active,.open>.dropdown-toggle.btn-openid{background-image:none}
+.btn-openid.disabled:hover,.btn-openid[disabled]:hover,fieldset[disabled] .btn-openid:hover,.btn-openid.disabled:focus,.btn-openid[disabled]:focus,fieldset[disabled] .btn-openid:focus,.btn-openid.disabled.focus,.btn-openid[disabled].focus,fieldset[disabled] .btn-openid.focus{background-color:#f7931e;border-color:rgba(0,0,0,0.2)}
+.btn-openid .badge{color:#f7931e;background-color:#fff}
+.btn-pinterest{color:#fff;background-color:#cb2027;border-color:rgba(0,0,0,0.2)}.btn-pinterest:focus,.btn-pinterest.focus{color:#fff;background-color:#9f191f;border-color:rgba(0,0,0,0.2)}
+.btn-pinterest:hover{color:#fff;background-color:#9f191f;border-color:rgba(0,0,0,0.2)}
+.btn-pinterest:active,.btn-pinterest.active,.open>.dropdown-toggle.btn-pinterest{color:#fff;background-color:#9f191f;border-color:rgba(0,0,0,0.2)}.btn-pinterest:active:hover,.btn-pinterest.active:hover,.open>.dropdown-toggle.btn-pinterest:hover,.btn-pinterest:active:focus,.btn-pinterest.active:focus,.open>.dropdown-toggle.btn-pinterest:focus,.btn-pinterest:active.focus,.btn-pinterest.active.focus,.open>.dropdown-toggle.btn-pinterest.focus{color:#fff;background-color:#801419;border-color:rgba(0,0,0,0.2)}
+.btn-pinterest:active,.btn-pinterest.active,.open>.dropdown-toggle.btn-pinterest{background-image:none}
+.btn-pinterest.disabled:hover,.btn-pinterest[disabled]:hover,fieldset[disabled] .btn-pinterest:hover,.btn-pinterest.disabled:focus,.btn-pinterest[disabled]:focus,fieldset[disabled] .btn-pinterest:focus,.btn-pinterest.disabled.focus,.btn-pinterest[disabled].focus,fieldset[disabled] .btn-pinterest.focus{background-color:#cb2027;border-color:rgba(0,0,0,0.2)}
+.btn-pinterest .badge{color:#cb2027;background-color:#fff}
+.btn-reddit{color:#000;background-color:#eff7ff;border-color:rgba(0,0,0,0.2)}.btn-reddit:focus,.btn-reddit.focus{color:#000;background-color:#bcddff;border-color:rgba(0,0,0,0.2)}
+.btn-reddit:hover{color:#000;background-color:#bcddff;border-color:rgba(0,0,0,0.2)}
+.btn-reddit:active,.btn-reddit.active,.open>.dropdown-toggle.btn-reddit{color:#000;background-color:#bcddff;border-color:rgba(0,0,0,0.2)}.btn-reddit:active:hover,.btn-reddit.active:hover,.open>.dropdown-toggle.btn-reddit:hover,.btn-reddit:active:focus,.btn-reddit.active:focus,.open>.dropdown-toggle.btn-reddit:focus,.btn-reddit:active.focus,.btn-reddit.active.focus,.open>.dropdown-toggle.btn-reddit.focus{color:#000;background-color:#98ccff;border-color:rgba(0,0,0,0.2)}
+.btn-reddit:active,.btn-reddit.active,.open>.dropdown-toggle.btn-reddit{background-image:none}
+.btn-reddit.disabled:hover,.btn-reddit[disabled]:hover,fieldset[disabled] .btn-reddit:hover,.btn-reddit.disabled:focus,.btn-reddit[disabled]:focus,fieldset[disabled] .btn-reddit:focus,.btn-reddit.disabled.focus,.btn-reddit[disabled].focus,fieldset[disabled] .btn-reddit.focus{background-color:#eff7ff;border-color:rgba(0,0,0,0.2)}
+.btn-reddit .badge{color:#eff7ff;background-color:#000}
+.btn-soundcloud{color:#fff;background-color:#f50;border-color:rgba(0,0,0,0.2)}.btn-soundcloud:focus,.btn-soundcloud.focus{color:#fff;background-color:#c40;border-color:rgba(0,0,0,0.2)}
+.btn-soundcloud:hover{color:#fff;background-color:#c40;border-color:rgba(0,0,0,0.2)}
+.btn-soundcloud:active,.btn-soundcloud.active,.open>.dropdown-toggle.btn-soundcloud{color:#fff;background-color:#c40;border-color:rgba(0,0,0,0.2)}.btn-soundcloud:active:hover,.btn-soundcloud.active:hover,.open>.dropdown-toggle.btn-soundcloud:hover,.btn-soundcloud:active:focus,.btn-soundcloud.active:focus,.open>.dropdown-toggle.btn-soundcloud:focus,.btn-soundcloud:active.focus,.btn-soundcloud.active.focus,.open>.dropdown-toggle.btn-soundcloud.focus{color:#fff;background-color:#a83800;border-color:rgba(0,0,0,0.2)}
+.btn-soundcloud:active,.btn-soundcloud.active,.open>.dropdown-toggle.btn-soundcloud{background-image:none}
+.btn-soundcloud.disabled:hover,.btn-soundcloud[disabled]:hover,fieldset[disabled] .btn-soundcloud:hover,.btn-soundcloud.disabled:focus,.btn-soundcloud[disabled]:focus,fieldset[disabled] .btn-soundcloud:focus,.btn-soundcloud.disabled.focus,.btn-soundcloud[disabled].focus,fieldset[disabled] .btn-soundcloud.focus{background-color:#f50;border-color:rgba(0,0,0,0.2)}
+.btn-soundcloud .badge{color:#f50;background-color:#fff}
+.btn-tumblr{color:#fff;background-color:#2c4762;border-color:rgba(0,0,0,0.2)}.btn-tumblr:focus,.btn-tumblr.focus{color:#fff;background-color:#1c2d3f;border-color:rgba(0,0,0,0.2)}
+.btn-tumblr:hover{color:#fff;background-color:#1c2d3f;border-color:rgba(0,0,0,0.2)}
+.btn-tumblr:active,.btn-tumblr.active,.open>.dropdown-toggle.btn-tumblr{color:#fff;background-color:#1c2d3f;border-color:rgba(0,0,0,0.2)}.btn-tumblr:active:hover,.btn-tumblr.active:hover,.open>.dropdown-toggle.btn-tumblr:hover,.btn-tumblr:active:focus,.btn-tumblr.active:focus,.open>.dropdown-toggle.btn-tumblr:focus,.btn-tumblr:active.focus,.btn-tumblr.active.focus,.open>.dropdown-toggle.btn-tumblr.focus{color:#fff;background-color:#111c26;border-color:rgba(0,0,0,0.2)}
+.btn-tumblr:active,.btn-tumblr.active,.open>.dropdown-toggle.btn-tumblr{background-image:none}
+.btn-tumblr.disabled:hover,.btn-tumblr[disabled]:hover,fieldset[disabled] .btn-tumblr:hover,.btn-tumblr.disabled:focus,.btn-tumblr[disabled]:focus,fieldset[disabled] .btn-tumblr:focus,.btn-tumblr.disabled.focus,.btn-tumblr[disabled].focus,fieldset[disabled] .btn-tumblr.focus{background-color:#2c4762;border-color:rgba(0,0,0,0.2)}
+.btn-tumblr .badge{color:#2c4762;background-color:#fff}
+.btn-twitter{color:#fff;background-color:#55acee;border-color:rgba(0,0,0,0.2)}.btn-twitter:focus,.btn-twitter.focus{color:#fff;background-color:#2795e9;border-color:rgba(0,0,0,0.2)}
+.btn-twitter:hover{color:#fff;background-color:#2795e9;border-color:rgba(0,0,0,0.2)}
+.btn-twitter:active,.btn-twitter.active,.open>.dropdown-toggle.btn-twitter{color:#fff;background-color:#2795e9;border-color:rgba(0,0,0,0.2)}.btn-twitter:active:hover,.btn-twitter.active:hover,.open>.dropdown-toggle.btn-twitter:hover,.btn-twitter:active:focus,.btn-twitter.active:focus,.open>.dropdown-toggle.btn-twitter:focus,.btn-twitter:active.focus,.btn-twitter.active.focus,.open>.dropdown-toggle.btn-twitter.focus{color:#fff;background-color:#1583d7;border-color:rgba(0,0,0,0.2)}
+.btn-twitter:active,.btn-twitter.active,.open>.dropdown-toggle.btn-twitter{background-image:none}
+.btn-twitter.disabled:hover,.btn-twitter[disabled]:hover,fieldset[disabled] .btn-twitter:hover,.btn-twitter.disabled:focus,.btn-twitter[disabled]:focus,fieldset[disabled] .btn-twitter:focus,.btn-twitter.disabled.focus,.btn-twitter[disabled].focus,fieldset[disabled] .btn-twitter.focus{background-color:#55acee;border-color:rgba(0,0,0,0.2)}
+.btn-twitter .badge{color:#55acee;background-color:#fff}
+.btn-vimeo{color:#fff;background-color:#1ab7ea;border-color:rgba(0,0,0,0.2)}.btn-vimeo:focus,.btn-vimeo.focus{color:#fff;background-color:#1295bf;border-color:rgba(0,0,0,0.2)}
+.btn-vimeo:hover{color:#fff;background-color:#1295bf;border-color:rgba(0,0,0,0.2)}
+.btn-vimeo:active,.btn-vimeo.active,.open>.dropdown-toggle.btn-vimeo{color:#fff;background-color:#1295bf;border-color:rgba(0,0,0,0.2)}.btn-vimeo:active:hover,.btn-vimeo.active:hover,.open>.dropdown-toggle.btn-vimeo:hover,.btn-vimeo:active:focus,.btn-vimeo.active:focus,.open>.dropdown-toggle.btn-vimeo:focus,.btn-vimeo:active.focus,.btn-vimeo.active.focus,.open>.dropdown-toggle.btn-vimeo.focus{color:#fff;background-color:#0f7b9f;border-color:rgba(0,0,0,0.2)}
+.btn-vimeo:active,.btn-vimeo.active,.open>.dropdown-toggle.btn-vimeo{background-image:none}
+.btn-vimeo.disabled:hover,.btn-vimeo[disabled]:hover,fieldset[disabled] .btn-vimeo:hover,.btn-vimeo.disabled:focus,.btn-vimeo[disabled]:focus,fieldset[disabled] .btn-vimeo:focus,.btn-vimeo.disabled.focus,.btn-vimeo[disabled].focus,fieldset[disabled] .btn-vimeo.focus{background-color:#1ab7ea;border-color:rgba(0,0,0,0.2)}
+.btn-vimeo .badge{color:#1ab7ea;background-color:#fff}
+.btn-vk{color:#fff;background-color:#587ea3;border-color:rgba(0,0,0,0.2)}.btn-vk:focus,.btn-vk.focus{color:#fff;background-color:#466482;border-color:rgba(0,0,0,0.2)}
+.btn-vk:hover{color:#fff;background-color:#466482;border-color:rgba(0,0,0,0.2)}
+.btn-vk:active,.btn-vk.active,.open>.dropdown-toggle.btn-vk{color:#fff;background-color:#466482;border-color:rgba(0,0,0,0.2)}.btn-vk:active:hover,.btn-vk.active:hover,.open>.dropdown-toggle.btn-vk:hover,.btn-vk:active:focus,.btn-vk.active:focus,.open>.dropdown-toggle.btn-vk:focus,.btn-vk:active.focus,.btn-vk.active.focus,.open>.dropdown-toggle.btn-vk.focus{color:#fff;background-color:#3a526b;border-color:rgba(0,0,0,0.2)}
+.btn-vk:active,.btn-vk.active,.open>.dropdown-toggle.btn-vk{background-image:none}
+.btn-vk.disabled:hover,.btn-vk[disabled]:hover,fieldset[disabled] .btn-vk:hover,.btn-vk.disabled:focus,.btn-vk[disabled]:focus,fieldset[disabled] .btn-vk:focus,.btn-vk.disabled.focus,.btn-vk[disabled].focus,fieldset[disabled] .btn-vk.focus{background-color:#587ea3;border-color:rgba(0,0,0,0.2)}
+.btn-vk .badge{color:#587ea3;background-color:#fff}
+.btn-yahoo{color:#fff;background-color:#720e9e;border-color:rgba(0,0,0,0.2)}.btn-yahoo:focus,.btn-yahoo.focus{color:#fff;background-color:#500a6f;border-color:rgba(0,0,0,0.2)}
+.btn-yahoo:hover{color:#fff;background-color:#500a6f;border-color:rgba(0,0,0,0.2)}
+.btn-yahoo:active,.btn-yahoo.active,.open>.dropdown-toggle.btn-yahoo{color:#fff;background-color:#500a6f;border-color:rgba(0,0,0,0.2)}.btn-yahoo:active:hover,.btn-yahoo.active:hover,.open>.dropdown-toggle.btn-yahoo:hover,.btn-yahoo:active:focus,.btn-yahoo.active:focus,.open>.dropdown-toggle.btn-yahoo:focus,.btn-yahoo:active.focus,.btn-yahoo.active.focus,.open>.dropdown-toggle.btn-yahoo.focus{color:#fff;background-color:#39074e;border-color:rgba(0,0,0,0.2)}
+.btn-yahoo:active,.btn-yahoo.active,.open>.dropdown-toggle.btn-yahoo{background-image:none}
+.btn-yahoo.disabled:hover,.btn-yahoo[disabled]:hover,fieldset[disabled] .btn-yahoo:hover,.btn-yahoo.disabled:focus,.btn-yahoo[disabled]:focus,fieldset[disabled] .btn-yahoo:focus,.btn-yahoo.disabled.focus,.btn-yahoo[disabled].focus,fieldset[disabled] .btn-yahoo.focus{background-color:#720e9e;border-color:rgba(0,0,0,0.2)}
+.btn-yahoo .badge{color:#720e9e;background-color:#fff}

--- a/app/static/js/entrepreneur/job_offers_list.js
+++ b/app/static/js/entrepreneur/job_offers_list.js
@@ -2,10 +2,10 @@ $(function () {
     'use strict';
 
     // Clean filter
-    $('#id_QJCleanVfilter').on('click', function () {
-      $('#id_QJVfilterForm')[0].reset();
+    $('#id_QJCleanJOfilter').on('click', function () {
+      $('#id_QJJOfilterForm')[0].reset();
       $('#id_category').val('');
-      $('#id_QJVfilterForm').submit();
+      $('#id_QJJOfilterForm').submit();
     });
 
     // City autocomplete

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -39,6 +39,15 @@
                     <h2>The Cannabis Industry Network</h2>
                     <p>Connect with companies and experts in different sectors of the cannabis industry.</p>
 
+                    <div class="row">
+                        <div class="col-sm-8 col-sm-offset-2 col-lg-4 col-lg-offset-4">
+                            <a href="{% url 'social:begin' 'facebook' %}" class="btn btn-block btn-social btn-facebook">
+                                <span class="fa fa-facebook"></span>
+                                Facebook login
+                            </a>
+                        </div>
+                    </div>
+
                     <form action="{% url 'account:signup_form_submit' %}" method="POST" class="qjane-home-signup-form" id="id-qjane-home-signup-form">
                         {% csrf_token %}
                         {% for field in signup_form.visible_fields %}
@@ -53,7 +62,7 @@
                     </form>
 
                     <br>
-                    <p><i>By clicking on "Sign up", you accept the <a href="https://queryjane.net/corporative/user-agreement/" target="_blank">terms of use</a></i> and the <a href="https://queryjane.net/corporative/privacy-policy/" target="_blank">privacy policy</a>.</p>
+                    <p><i>Registering, you are accepting the <a href="https://queryjane.net/corporative/user-agreement/" target="_blank">terms of use</a></i> and the <a href="https://queryjane.net/corporative/privacy-policy/" target="_blank">privacy policy</a>.</p>
                 </div>
             </div>
         </div>

--- a/app/templates/layout/index.html
+++ b/app/templates/layout/index.html
@@ -7,6 +7,12 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <!-- The above 3 meta tags *must* come first in the head -->
+
+        <meta property="fb:app_id" content="{{ FACEBOOK_APP_ID }}">
+        <meta itemprop="type" property="og:type" content="website">
+        <meta property="og:site_name" content="QueryJane">
+        <meta property="og:url" content="https://{{ request.get_host }}{{ request.get_full_path }}">
+
         <meta name="description" content="">
         <meta name="author" content="QueryJane">
 
@@ -19,9 +25,13 @@
         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" crossorigin="anonymous">
 
         <link href="{% static 'dist/assets/css/bootstrap.min.css' %}" rel="stylesheet">
+
         <link href="//cdn.quilljs.com/1.3.4/quill.snow.css" rel="stylesheet">
 
         <link href="{% static 'css/libs/typeahead.css' %}" rel="stylesheet">
+
+        <link href="{% static 'css/libs/bootstrap-social.css' %}" rel="stylesheet">
+
         <link href="{% static 'dist/css/layout/layout.css' %}" rel="stylesheet">
         <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
         <!--[if lt IE 9]>

--- a/app/templates/layout/menu/_auth_and_non_auth_navbar.html
+++ b/app/templates/layout/menu/_auth_and_non_auth_navbar.html
@@ -1,0 +1,25 @@
+{% load static %}
+<nav class="navbar navbar-default main-nav-container is-authenticated">
+    <div class="container">
+        <div class="navbar-header">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button>
+
+            <a class="navbar-brand logotype-wrapper--authenticated" href="/">
+                <img class="logotype-wrapper__image--authenticated" src="{% static 'img/brand-authenticated.svg' %}" alt="Logitpo Query Jane">
+            </a>
+        </div>
+
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+            {% if user.is_authenticated %}
+                {% include 'layout/menu/_navbar_user_menu.html' %}
+            {% else %}
+                {% include 'layout/menu/_navbar_login_form.html' %}
+            {% endif %}
+        </div>
+    </div>
+</nav>

--- a/app/templates/layout/menu/_navbar_login_form.html
+++ b/app/templates/layout/menu/_navbar_login_form.html
@@ -4,11 +4,11 @@
         <a class="nav-link dropdown-toggle main-nav-items__item" href="#" id="supportedContentDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Log in</a>
 
         <ul class="dropdown-menu">
-            <!-- <li class="dropdown-item">
-                <p>Ingresa con tu cuenta de:</p>
-                <a class="QJFBLogin" href="#">Facebook</a>
-                <a class="QJGMLogin" href="#">Gmail</a>
-            </li> -->
+            <a href="{% url 'social:begin' 'facebook' %}" class="btn btn-block btn-social btn-facebook">
+                <span class="fa fa-facebook"></span>
+                Facebook login
+            </a>
+
             <li>
                 <div class="dropdown-item qjane-navbar-login-container">
                 {% get_login_form as login_form %}

--- a/app/urls.py
+++ b/app/urls.py
@@ -19,6 +19,7 @@ admin.site.site_header = 'QueryJane - Administrador'
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
+    url(r'^social/', include('social_django.urls', namespace='social')),
 
     url(
         r'^$',

--- a/corporative/templates/corporative/corporative_info_detail.html
+++ b/corporative/templates/corporative/corporative_info_detail.html
@@ -5,30 +5,7 @@
 {% block title %}{{ object }}{% endblock %}
 
 {% block navbar %}
-<nav class="navbar navbar-default main-nav-container is-authenticated">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-
-            <a class="navbar-brand logotype-wrapper--authenticated" href="/">
-                <img class="logotype-wrapper__image--authenticated" src="{% static 'img/brand-authenticated.svg' %}" alt="Logitpo Query Jane">
-            </a>
-        </div>
-
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            {% if user.is_authenticated %}
-                {% include 'layout/menu/_navbar_user_menu.html' %}
-            {% else %}
-                {% include 'layout/menu/_navbar_login_form.html' %}
-            {% endif %}
-        </div>
-    </div>
-</nav>
+{% include 'layout/menu/_auth_and_non_auth_navbar.html' %}
 {% endblock %}
 
 {% block content %}

--- a/entrepreneur/forms.py
+++ b/entrepreneur/forms.py
@@ -62,6 +62,58 @@ class VentureFilter(forms.Form):
         super().__init__(*args, **kwargs)
 
 
+class JobOffersFilter(forms.Form):
+    country_search = forms.CharField(
+        required=False,
+        label='Country',
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': 'Type the country name and select one from the list.',
+            },
+        ),
+    )
+
+    country_code = forms.CharField(
+        required=False,
+        label='country code',
+    )
+
+    city_search = forms.CharField(
+        required=False,
+        label='City',
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': 'Type de city name.',
+            },
+        ),
+    )
+
+    city_id = forms.CharField(
+        required=False,
+        label='city id',
+    )
+
+    category = forms.ModelChoiceField(
+        required=False,
+        queryset=IndustryCategory.objects.all(),
+        label='Sector',
+        empty_label='all sector',
+    )
+
+    venture_search = forms.CharField(
+        label='Company',
+        required=False,
+    )
+
+    venture_id = forms.CharField(
+        required=False,
+        label='company id',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
 class VentureForm(ModelForm):
     name = forms.CharField(
         required=True,

--- a/entrepreneur/templates/entrepreneur/job_detail.html
+++ b/entrepreneur/templates/entrepreneur/job_detail.html
@@ -5,30 +5,7 @@
 {% block title %}{{ venture }}{% endblock %}
 
 {% block navbar %}
-<nav class="navbar navbar-default main-nav-container is-authenticated">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-
-            <a class="navbar-brand logotype-wrapper--authenticated" href="/">
-                <img class="logotype-wrapper__image--authenticated" src="{% static 'img/brand-authenticated.svg' %}" alt="Logitpo Query Jane">
-            </a>
-        </div>
-
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            {% if user.is_authenticated %}
-                {% include 'layout/menu/_navbar_user_menu.html' %}
-            {% else %}
-                {% include 'layout/menu/_navbar_login_form.html' %}
-            {% endif %}
-        </div>
-    </div>
-</nav>
+{% include 'layout/menu/_auth_and_non_auth_navbar.html' %}
 {% endblock %}
 
 {% block content %}

--- a/entrepreneur/templates/entrepreneur/jobs_list.html
+++ b/entrepreneur/templates/entrepreneur/jobs_list.html
@@ -4,30 +4,7 @@
 {% block title %}Job offers{% endblock %}
 
 {% block navbar %}
-<nav class="navbar navbar-default main-nav-container is-authenticated">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-
-            <a class="navbar-brand logotype-wrapper--authenticated" href="/">
-                <img class="logotype-wrapper__image--authenticated" src="{% static 'img/brand-authenticated.svg' %}" alt="Logitpo Query Jane">
-            </a>
-        </div>
-
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            {% if user.is_authenticated %}
-                {% include 'layout/menu/_navbar_user_menu.html' %}
-            {% else %}
-                {% include 'layout/menu/_navbar_login_form.html' %}
-            {% endif %}
-        </div>
-    </div>
-</nav>
+{% include 'layout/menu/_auth_and_non_auth_navbar.html' %}
 {% endblock %}
 
 {% block content %}

--- a/entrepreneur/templates/entrepreneur/jobs_list.html
+++ b/entrepreneur/templates/entrepreneur/jobs_list.html
@@ -10,6 +10,53 @@
 {% block content %}
 <section class="account">
     <div class="container">
+        <div class="QJJOFilterForm">
+            <form id="id_QJJOfilterForm" method="get" class="clearfix">
+                <div class="row">
+                    <div class="col-md-6 col-sm-6 col-xs-12">
+                        <div id="id_QjaneVFcountryAut" class="form-group" data-country-autocomplete-url="{% url 'place:country_search' %}">
+                            {{ filter_form.country_search.label_tag }}
+                            {% render_field filter_form.country_search class+="form-control" %}
+                            <img id="id_QjaneVFcountryAutImg" src="{{ country_instance.country.flag }}">
+
+                            <div style="display:none">
+                            {% render_field filter_form.country_code %}
+                            </div>
+                        </div>                                
+                        <div class="form-group">
+                            {{ filter_form.category.label_tag }}
+                            {% render_field filter_form.category class+="form-control" %}
+                            {{ filter_form.category.errors }}
+                        </div>
+                    </div>
+
+                    <div class="form-group col-md-6 col-sm-6 col-xs-12">
+                        <div class="form-group" id="id_QjaneVFcityAut" data-ax-city-autocomplete-url="{% url 'place:city_search' %}">
+                            {{ filter_form.city_search.label_tag }}
+                            {% render_field filter_form.city_search class+="form-control" %}
+                            {{ filter_form.city_search.errors }}
+
+                            <div style="display:none">
+                            {% render_field filter_form.city_id %}
+                            </div>
+                        </div>
+                        <div id="id_QjaneVListAut" class="form-group" data-ax-ventury-autocomplete-url="{% url 'entrepreneur:ax_ventury_autocomplete' %}">
+                            {{ filter_form.venture_search.label_tag }}
+                            {% render_field filter_form.venture_search class+="form-control" %}
+                            {{ filter_form.venture_search.errors }}
+
+                            <div style="display:none">
+                            {% render_field filter_form.venture_id %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <a href="javascript:void(0)" id="id_QJCleanJOfilter" class="btn btn-ghost-purple">Clean</a>
+                <button type="submit" class="btn btn-primary">Search</button>
+            </form>
+        </div>
+        <br>
+
         <div class="panel panel-primary">
             <div class="panel-heading">
                 <h3 class="panel-title">Job offers</h3>
@@ -74,6 +121,12 @@
                         </div>
                       </td>
                     </tr>
+                    {% empty %}
+                    <tr>
+                        <td>
+                            No job offers found.
+                        </td>
+                    </tr>
                     {% endfor %}
                   </tbody>
                 </table>
@@ -86,6 +139,5 @@
 
 {% block js %}
 <script src="{% static 'js/place/place_autocomplete.js' %}"></script>
-<script src="{% static 'js/entrepreneur/venture_list.js' %}"></script>
+<script src="{% static 'js/entrepreneur/job_offers_list.js' %}"></script>
 {% endblock %}
-

--- a/entrepreneur/templates/entrepreneur/venture_list.html
+++ b/entrepreneur/templates/entrepreneur/venture_list.html
@@ -4,30 +4,7 @@
 {% block title %}Companies{% endblock %}
 
 {% block navbar %}
-<nav class="navbar navbar-default main-nav-container is-authenticated">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-
-            <a class="navbar-brand logotype-wrapper--authenticated" href="/">
-                <img class="logotype-wrapper__image--authenticated" src="{% static 'img/brand-authenticated.svg' %}" alt="Logitpo Query Jane">
-            </a>
-        </div>
-
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            {% if user.is_authenticated %}
-                {% include 'layout/menu/_navbar_user_menu.html' %}
-            {% else %}
-                {% include 'layout/menu/_navbar_login_form.html' %}
-            {% endif %}
-        </div>
-    </div>
-</nav>
+{% include 'layout/menu/_auth_and_non_auth_navbar.html' %}
 {% endblock %}
 
 {% block content %}

--- a/entrepreneur/templates/entrepreneur/venture_profile.html
+++ b/entrepreneur/templates/entrepreneur/venture_profile.html
@@ -5,30 +5,7 @@
 {% block title %}{{ venture }}{% endblock %}
 
 {% block navbar %}
-<nav class="navbar navbar-default main-nav-container is-authenticated">
-    <div class="container">
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-
-            <a class="navbar-brand logotype-wrapper--authenticated" href="/">
-                <img class="logotype-wrapper__image--authenticated" src="{% static 'img/brand-authenticated.svg' %}" alt="Logitpo Query Jane">
-            </a>
-        </div>
-
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            {% if user.is_authenticated %}
-                {% include 'layout/menu/_navbar_user_menu.html' %}
-            {% else %}
-                {% include 'layout/menu/_navbar_login_form.html' %}
-            {% endif %}
-        </div>
-    </div>
-</nav>
+{% include 'layout/menu/_auth_and_non_auth_navbar.html' %}
 {% endblock %}
 
 {% block content %}

--- a/entrepreneur/templates/entrepreneur/venture_settings/_membership_line.html
+++ b/entrepreneur/templates/entrepreneur/venture_settings/_membership_line.html
@@ -8,7 +8,7 @@
 
     <div class="media-body">
         <h4 class="media-heading">{{ membership.admin.get_print }}</h4>
-        <p>{{ membership.admin.user.email }}</p>
+        <p>{{ membership.admin.slug }}</p>
         <p>{{ membership.get_role_display }}</p>
     </div>
 

--- a/entrepreneur/templates/entrepreneur/venture_settings/_userprofile_line.html
+++ b/entrepreneur/templates/entrepreneur/venture_settings/_userprofile_line.html
@@ -8,7 +8,7 @@
 
     <div class="media-body">
         <h4 class="media-heading">{{ userprofile.get_print }}</h4>
-        <p>{{ userprofile.user.email }}</p>
+        <p>{{ userprofile.slug }}</p>
     </div>
 
     <div class="media-right">

--- a/place/utils.py
+++ b/place/utils.py
@@ -15,10 +15,10 @@ def get_user_country(META):
         return None
 
     gi = pygeoip.GeoIP('app/static/GeoIP.dat')
-    # country_code = gi.country_code_by_addr('190.252.158.138')
-    # country_name = gi.country_name_by_addr('190.252.158.138')
-    country_code = gi.country_code_by_addr(ip)
-    country_name = gi.country_name_by_addr(ip)
+    country_code = gi.country_code_by_addr('190.252.158.138')
+    country_name = gi.country_name_by_addr('190.252.158.138')
+    # country_code = gi.country_code_by_addr(ip)
+    # country_name = gi.country_name_by_addr(ip)
 
     country_instance = None
 

--- a/place/utils.py
+++ b/place/utils.py
@@ -15,10 +15,10 @@ def get_user_country(META):
         return None
 
     gi = pygeoip.GeoIP('app/static/GeoIP.dat')
-    country_code = gi.country_code_by_addr('190.252.158.138')
-    country_name = gi.country_name_by_addr('190.252.158.138')
-    # country_code = gi.country_code_by_addr(ip)
-    # country_name = gi.country_name_by_addr(ip)
+    # country_code = gi.country_code_by_addr('190.252.158.138')
+    # country_name = gi.country_name_by_addr('190.252.158.138')
+    country_code = gi.country_code_by_addr(ip)
+    country_name = gi.country_name_by_addr(ip)
 
     country_instance = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ psycopg2==2.6.2
 Pillow==3.3.1
 boto3==1.4.6
 pygeoip==0.3.2
+social-auth-app-django==2.1.0
 
 # Apps
 django-widget-tweaks==1.4.1


### PR DESCRIPTION
## Integrated social-auth-app-django

To prevent users being forced to remember a new password to use the application, I have integrated [social-auth-app-django](https://github.com/python-social-auth/social-app-django). Now, users can register and login in the application through their fb account.

### Other changes included in this pull request:

1. **Avoid display users email**: There was a bug in the *Roles* section on companies settings menu. Users can search other users by name, username or email. The email was displayed when a user was found. In order to respect users privacy, email has been hidden from all page sections.

2. **Code recycling**: Refactoring code for *auth and non-auth* common sections navigation bar.

3. **Added Job offers filter**: Enabled job offers filter. Now users can filter job offers by country, city, category and company.

